### PR TITLE
Adding support for custom CAs and fixing bugs

### DIFF
--- a/charts/rancher-csp-adapter/templates/deployment.yaml
+++ b/charts/rancher-csp-adapter/templates/deployment.yaml
@@ -29,4 +29,18 @@ spec:
         image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         name: {{ .Chart.Name }}
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+{{- if .Values.additionalTrustedCAs }}
+        volumeMounts:
+          - mountPath: /etc/ssl/certs/rancher-cert.pem
+            name: tls-ca-volume
+            subPath: ca-additional.pem
+            readOnly: true
+{{- end }}
       serviceAccountName: {{ .Chart.Name }}
+{{- if .Values.additionalTrustedCAs }}
+      volumes:
+        - name: tls-ca-volume
+          secret:
+            defaultMode: 0444
+            secretName: tls-ca-additional
+{{- end }}

--- a/charts/rancher-csp-adapter/values.yaml
+++ b/charts/rancher-csp-adapter/values.yaml
@@ -11,6 +11,10 @@ global:
 
 tolerations: []
 
+# if rancher is using a privateCA, this certificate must be provided as a secret in the adapter's namespace - see the
+# readme/docs for more details
+#additionalTrustedCAs: true
+
 # at least one csp must be enabled like below
 aws:
   enabled: false

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,14 @@
 FROM registry.suse.com/bci/bci-micro:15.3
-RUN mkdir -p supportconfig/rancher/
+
+ARG user=adapter
+
+RUN echo "$user:x:1000:1000::/home/$user:/bin/bash" >> /etc/passwd && \
+    echo "$user:x:1000:" >> /etc/group && \
+    mkdir /home/$user && \
+    chown -R $user:$user /home/$user
+
 COPY bin/csp-adapter /usr/bin/
+
+USER $user
+
 CMD ["csp-adapter"]

--- a/pkg/manager/aws.go
+++ b/pkg/manager/aws.go
@@ -146,10 +146,10 @@ func (m *AWS) runComplianceCheck(ctx context.Context) error {
 	if currentCheckoutInfo.EntitledLicenses == requiredLicenses {
 		statusMessage = fmt.Sprintf("%s Rancher server has the required amount of licenses", statusPrefix)
 	} else {
-		statusMessage = fmt.Sprintf("%s You have exceeded your licensed node count. At least %d more licens(es) are required in AWS to become compliant.",
+		statusMessage = fmt.Sprintf("%s You have exceeded your licensed node count. At least %d more license(s) are required in AWS to become compliant.",
 			statusPrefix, requiredLicenses-currentCheckoutInfo.EntitledLicenses)
 	}
-	configMessage := fmt.Sprintf("Rancher server required %d licens(es) and was able to check out %d licens(es)", requiredLicenses, currentCheckoutInfo.EntitledLicenses)
+	configMessage := fmt.Sprintf("Rancher server required %d license(s) and was able to check out %d license(s)", requiredLicenses, currentCheckoutInfo.EntitledLicenses)
 
 	return m.updateAdapterOutput(currentCheckoutInfo.EntitledLicenses == requiredLicenses, configMessage, statusMessage)
 }

--- a/pkg/metrics/scraper.go
+++ b/pkg/metrics/scraper.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
@@ -22,14 +21,9 @@ type scraper struct {
 }
 
 func NewScraper(rancherHost string, cfg *rest.Config) Scraper {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-	}
 	return &scraper{
 		metricsURL: strings.Join([]string{"https://", rancherHost, "/metrics"}, ""),
-		cli:        &http.Client{Transport: tr},
+		cli:        &http.Client{},
 		cfg:        cfg,
 	}
 }


### PR DESCRIPTION
Makes the following changes:
- Adds support for private CAs
- Fixes spelling bug in "out of compliance" messages
- Changes the container to use a non-root user
- Changes the scraper to validate TLS certs
- Updates the readme with details on certs