### PR TITLE
Adding default aws registry

### DIFF
--- a/charts/rancher-csp-adapter/templates/_helpers.tpl
+++ b/charts/rancher-csp-adapter/templates/_helpers.tpl
@@ -1,11 +1,3 @@
-{{- define "system_default_registry" -}}
-{{- if .Values.global.cattle.systemDefaultRegistry -}}
-{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
-{{- else -}}
-{{- "" -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "csp-adapter.labels" -}}
 app: rancher-csp-adapter
 {{- end }}
@@ -51,3 +43,15 @@ aws
 false
 {{- end -}}
 {{- end }}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+    {{- if eq (include "csp-adapter.csp" .) "aws" -}}
+    {{- "709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/" -}}
+    {{- else -}}
+    {{- "" -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Background

Customers will need to install an image from the AWS registry owned by suse during installation of the chart from the marketplace. This PR aims to make the default image pulled from a suse owned ECR registry rather than dockerhub if AWS is selected as the csp provider.

## Changes
- The system default registry is now calculated last in the _helpers.tpl
- If a system default registry is specified by the end user, the chart uses that value (to support airgap registries)
- If the system default registry is not specified by the end user and we are deploying in aws (i.e `aws.enabled` == `true`), we use the suse ecr registry
- If the system default registry is not specified by the end user and we are not deploying in aws, then we use dockerhub as in the current state

## FAQ

- Why is this change being made?

In the current state, customers will need to specify a default registry or image repository when installing the adapter from the marketplace, making their end values.yaml/helm install cli command more complex. This will allow for a simplified install command.

## Notes
This PR depends on #16 which pushes the csp adapter image to ecr.