### PR TITLE
Changing manifest stage to push amd64 image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -198,7 +198,7 @@ steps:
     - tag
 
 - name: aws-manifest
-  image: plugins/ecr
+  image: registry.suse.com/bci/bci-base:latest
   environment:
     AWS_REGISTRY_ID:
       from_secret: aws_registry_id
@@ -208,6 +208,7 @@ steps:
       from_secret: ecr_secret_key
     AWS_REGION: "us-east-1"
   commands:
+  - "zypper in -y aws-cli docker"
   - "aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_REGISTRY_ID"
   - "docker manifest create $AWS_REGISTRY_ID/suse/rancher/rancher-csp-adapter:${DRONE_TAG} $AWS_REGISTRY_ID/suse/rancher/rancher-csp-adapter:${DRONE_TAG}-arm64 $AWS_REGISTRY_ID/suse/rancher/rancher-csp-adapter:${DRONE_TAG}-amd64"
   - "docker manifest push $AWS_REGISTRY_ID/suse/rancher/rancher-csp-adapter:${DRONE_TAG}"


### PR DESCRIPTION
Currently, our pipeline process makes use of drone plugins. The relevant plugins for pushing to ecr and creating a manifest (for support on multi-arch images) are `plugins/ecr` and `plugins/manifest` respectively. The ecr plugin, however, does not appear to support manifests and the manifest plugin does not appear to support ECR credentials.

I attempted to get around this by using a custom command to create the registry, but was unable to find an image which contained both the aws cli and the docker cli (there are images on dockerhub, but the sources aren't official and would represent a security risk). We could push one, but this would add a maintenance burden over time.

To get around this, we are just going to push the amd64 image as the tagged image. However, the amd64 image will still be pushed to a repo and still can be used, the user will just have to manually specify the tag (so `v1.0.0` will be `v1.0.0-amd64` and you will need to manually specify `v1.0.0-arm64` to use an arm image). Eventually, we will want this to be fixed, but given the deadlines this solution is acceptable.