### PR TITLE
Adding support for second product id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ replace (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.16.2
 	github.com/aws/aws-sdk-go-v2/config v1.15.3
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.15.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.3
@@ -49,6 +48,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.16.2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9 // indirect

--- a/pkg/clients/aws/client_test.go
+++ b/pkg/clients/aws/client_test.go
@@ -1,0 +1,96 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const fakeAccountNum = "123456789101"
+
+func TestGetRancherLicense(t *testing.T) {
+	tests := []struct {
+		name              string // name of the test, to be displayed on failure
+		hasNonEmeaLicense bool   // if the account has a license for the non-EMEA product sku
+		hasEmeaLicense    bool   // if the account has a licensed for the EMEA product sku
+		includeProductSku bool   // if the return from aws should include or exclude a product sku
+		desiredLicense    string // which license our client should pick - emea, non-emea, or nothing
+		errDesired        bool   // if we wanted an error for this test case
+	}{
+		{
+			name:              "test non-emea license",
+			hasNonEmeaLicense: true,
+			hasEmeaLicense:    false,
+			includeProductSku: true,
+			desiredLicense:    rancherProductSKUNonEmea,
+			errDesired:        false,
+		},
+		{
+			name:              "test emea license",
+			hasNonEmeaLicense: false,
+			hasEmeaLicense:    true,
+			includeProductSku: true,
+			desiredLicense:    rancherProductSKUEmea,
+			errDesired:        false,
+		},
+		{
+			name:              "test non-emea + emea license - should not occur in reality",
+			hasNonEmeaLicense: true,
+			hasEmeaLicense:    true,
+			includeProductSku: true,
+			desiredLicense:    rancherProductSKUNonEmea,
+			errDesired:        false,
+		},
+		{
+			name:              "test no valid license",
+			hasNonEmeaLicense: false,
+			hasEmeaLicense:    false,
+			includeProductSku: false,
+			desiredLicense:    "",
+			errDesired:        true,
+		},
+		{
+			name:              "test no product sku non-emea",
+			hasNonEmeaLicense: true,
+			hasEmeaLicense:    false,
+			includeProductSku: false,
+			desiredLicense:    rancherProductSKUNonEmea,
+			errDesired:        false,
+		},
+		{
+			name:              "test no product sku emea",
+			hasNonEmeaLicense: false,
+			hasEmeaLicense:    true,
+			includeProductSku: false,
+			desiredLicense:    rancherProductSKUEmea,
+			errDesired:        false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			mockLMClient := mockLicenseManagerClient{}
+			client := &client{
+				acctNum: fakeAccountNum,
+				lm:      &mockLMClient,
+				sts:     &mockSTSClient{accountNumber: fakeAccountNum},
+			}
+			if test.hasNonEmeaLicense {
+				mockLMClient.AddLicenseForSku(rancherProductSKUNonEmea, fakeAccountNum, test.includeProductSku)
+			}
+			if test.hasEmeaLicense {
+				mockLMClient.AddLicenseForSku(rancherProductSKUEmea, fakeAccountNum, test.includeProductSku)
+			}
+
+			license, err := client.GetRancherLicense(context.Background())
+			if test.errDesired {
+				assert.Error(t, err, "expected an error but err was nil")
+			} else {
+				assert.NoError(t, err, "no error was expected, but got an error")
+				assert.NotNil(t, license, "expected a valid license but was nil")
+				assert.Equal(t, *license.ProductSKU, test.desiredLicense, "received unexpected product sku")
+			}
+		})
+	}
+}

--- a/pkg/clients/aws/mocks_test.go
+++ b/pkg/clients/aws/mocks_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	lm "github.com/aws/aws-sdk-go-v2/service/licensemanager"
+	"github.com/aws/aws-sdk-go-v2/service/licensemanager/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+const timeFormat = time.RFC3339
+
+type mockLicenseManagerClient struct {
+	licenses           map[string]types.GrantedLicense
+	checkedOutLicenses map[string]licenseInfo
+	licenseCounter     int
+}
+
+type mockSTSClient struct {
+	accountNumber string
+}
+
+type licenseInfo struct {
+	checkOutInput lm.CheckoutLicenseInput
+	expiryTime    time.Time
+}
+
+func (m *mockLicenseManagerClient) AddLicenseForSku(productSku string, accountNumber string, includeSkuInReturn bool) {
+	if m.licenses == nil {
+		m.licenses = map[string]types.GrantedLicense{}
+	}
+	licenseArn := fmt.Sprintf("arn:aws:license-manager::%s:license:l-%06d", accountNumber, m.licenseCounter)
+	m.licenseCounter++
+	license := types.GrantedLicense{
+		LicenseArn: &licenseArn,
+	}
+	if includeSkuInReturn {
+		license.ProductSKU = &productSku
+	}
+	m.licenses[productSku] = license
+}
+
+func (m *mockLicenseManagerClient) Clear() {
+	m.licenses = map[string]types.GrantedLicense{}
+	m.checkedOutLicenses = map[string]licenseInfo{}
+	m.licenseCounter = 0
+}
+
+func (m *mockLicenseManagerClient) ListReceivedLicenses(ctx context.Context, params *lm.ListReceivedLicensesInput, optFns ...func(*lm.Options)) (*lm.ListReceivedLicensesOutput, error) {
+	var productIDs []string
+	for _, filter := range params.Filters {
+		if *filter.Name == productSKUField {
+			productIDs = filter.Values
+		}
+	}
+	var licenses []types.GrantedLicense
+	for _, productID := range productIDs {
+		if license, ok := m.licenses[productID]; ok {
+			licenses = append(licenses, license)
+		}
+	}
+	return &lm.ListReceivedLicensesOutput{
+		Licenses: licenses,
+	}, nil
+}
+func (m *mockLicenseManagerClient) CheckoutLicense(ctx context.Context, params *lm.CheckoutLicenseInput, optFns ...func(*lm.Options)) (*lm.CheckoutLicenseOutput, error) {
+	consumptionToken := params.ClientToken
+	if consumptionToken == nil {
+		return nil, fmt.Errorf("unable to checkout license, no consumption token provided")
+	}
+	expiryTime := time.Now().Add(time.Hour * 24)
+	expiryTS := expiryTime.Format(timeFormat)
+	m.checkedOutLicenses[*consumptionToken] = licenseInfo{
+		checkOutInput: *params,
+		expiryTime:    expiryTime,
+	}
+	return &lm.CheckoutLicenseOutput{
+		LicenseConsumptionToken: consumptionToken,
+		Expiration:              &expiryTS,
+	}, nil
+}
+func (m *mockLicenseManagerClient) CheckInLicense(ctx context.Context, params *lm.CheckInLicenseInput, optFns ...func(*lm.Options)) (*lm.CheckInLicenseOutput, error) {
+	if params.LicenseConsumptionToken == nil {
+		return nil, fmt.Errorf("can't check in license without consumption token")
+	}
+	if _, ok := m.checkedOutLicenses[*params.LicenseConsumptionToken]; ok {
+		return nil, fmt.Errorf("no license checked in for consumption token")
+	}
+	delete(m.checkedOutLicenses, *params.LicenseConsumptionToken)
+	return nil, nil
+}
+func (m *mockLicenseManagerClient) ExtendLicenseConsumption(ctx context.Context, params *lm.ExtendLicenseConsumptionInput, optFns ...func(*lm.Options)) (*lm.ExtendLicenseConsumptionOutput, error) {
+	token := params.LicenseConsumptionToken
+	if token == nil {
+		return nil, fmt.Errorf("no token provided, cannot extend checkout")
+	}
+	if _, ok := m.checkedOutLicenses[*token]; ok {
+		return nil, fmt.Errorf("no license checked in for consumption token")
+	}
+	return nil, nil
+}
+func (m *mockLicenseManagerClient) GetLicenseUsage(ctx context.Context, params *lm.GetLicenseUsageInput, optFns ...func(*lm.Options)) (*lm.GetLicenseUsageOutput, error) {
+	licenseArn := params.LicenseArn
+	if licenseArn == nil {
+		return nil, fmt.Errorf("license arn is missing but is required")
+	}
+	var entitlementUsage []types.EntitlementUsage
+	for _, value := range m.checkedOutLicenses {
+		// find only the check-outs for this license
+		if license, ok := m.licenses[*value.checkOutInput.ProductSKU]; ok {
+			if *license.LicenseArn == *licenseArn {
+				// add each usage separately, no need to combine into one
+				for _, data := range value.checkOutInput.Entitlements {
+					entitlementUsage = append(entitlementUsage, types.EntitlementUsage{Name: data.Name, ConsumedValue: data.Value, Unit: data.Unit})
+				}
+			}
+		}
+	}
+	return &lm.GetLicenseUsageOutput{
+		LicenseUsage: &types.LicenseUsage{EntitlementUsages: entitlementUsage}}, nil
+}
+
+func (m *mockSTSClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{Account: &m.accountNumber}, nil
+}


### PR DESCRIPTION
## Background

For various billing reasons, the aws marketplace entry for the adapter will be published in two separate listings. Each will only work for enumerated non-overlapping regions. The csp adapter will need to be able to use either of these listings in order to fully support both products.

## Changes
- There are now two product ids - one for AMEA and one for not AMEA.
- We try to checkout the AMEA license first, and try the non-AMEA license if we fail
- Because we are using two different product ids, we now use the product sku from the retrieved license when checking out the license rather than using the const value

## FAQ
- Couldn't we just have this set as a variable and specify this as a build variable in the chart or in the docker build process?
We could - however if this was set in the build process, this would cause us to have to maintain 2 images (both in aws and dockerhub) or to have to maintain an option in the chart which users would have to set (making the user experience worse). This option allows us to have little to no user interaction and no new container images.

## Notes
- The new product id is still pending. 