### PR TITLE
Update the Rancher version limit range for the chart

### DIFF
--- a/charts/rancher-csp-adapter/Chart.yaml
+++ b/charts/rancher-csp-adapter/Chart.yaml
@@ -12,5 +12,5 @@ annotations:
   catalog.cattle.io/scope: management
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux
-  catalog.cattle.io/rancher-version: '>= 2.6.6-0 < 2.7.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
   catalog.cattle.io/kube-version: '>= 1.22.0-0 < 1.25.0-0'


### PR DESCRIPTION
Updating the Rancher version limit range in preparation for a separate v2.0.0-rc1 version of the chart.