### PR TITLE
[release/v2.6] Bump BCI to 15.4

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-micro:15.3
+FROM registry.suse.com/bci/bci-micro:15.4
 
 ARG user=adapter
 


### PR DESCRIPTION
Backport of https://github.com/rancher/csp-adapter/pull/29