### PR TITLE
Adding a dev mode

### DIFF
--- a/charts/rancher-csp-adapter/templates/deployment.yaml
+++ b/charts/rancher-csp-adapter/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       - env:
         - name: CATTLE_DEBUG
           value: {{ .Values.debug | quote }}
+        - name: CATTLE_DEV_MODE
+          value: {{ .Values.devMode | quote }}
         - name: K8S_OUTPUT_CONFIGMAP
           value: '{{ template "csp-adapter.outputConfigMap"  }}'
         - name: K8S_OUTPUT_NOTIFICATION

--- a/charts/rancher-csp-adapter/values.yaml
+++ b/charts/rancher-csp-adapter/values.yaml
@@ -1,4 +1,6 @@
 debug: false
+# used for development only - not supported in production
+devMode: false
 
 image:
   repository: rancher/rancher-csp-adapter

--- a/main.go
+++ b/main.go
@@ -28,8 +28,9 @@ func main() {
 }
 
 const (
-	debugEnv = "CATTLE_DEBUG"
-	awsCSP   = "aws"
+	debugEnv   = "CATTLE_DEBUG"
+	devModeEnv = "CATTLE_DEV_MODE"
+	awsCSP     = "aws"
 )
 
 func run() error {
@@ -55,7 +56,9 @@ func run() error {
 		return err
 	}
 
-	awsClient, err := aws.NewClient(ctx)
+	devMode := os.Getenv(devModeEnv) == "true"
+
+	awsClient, err := aws.NewClient(ctx, devMode)
 	if err != nil {
 		registerErr := registerStartupError(k8sClients, createCSPInfo(awsCSP, "unknown"), err)
 		if registerErr != nil {


### PR DESCRIPTION
## Overview

Adds a dev mode which makes the adapter use a new set of test ids. Related to rancher/rancher#39087.

## Changes
- Adds a new set of test ids that are used by the adapter 
- Adds a new env var for `devMode` which tells the adapter to use the test ids
- Adds a new value to the helm chart to allow devMode to be set without manually changing the deployment
- Adds new tests to account for new ids

## Tests
Old unit tests pass, new unit tests pass, also conducted a manual test to make sure the chart changes worked.