### PR TITLE
Update helm version to resolve CVEs

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN zypper -n up && \
 RUN if [ "${ARCH}" == "amd64" ]; then \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2; \
     fi
-RUN curl -sL https://get.helm.sh/helm-v3.5.4-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
+RUN curl -sL https://get.helm.sh/helm-v3.12.0-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
 ENV DAPPER_SOURCE /go/src/github.com/rancher/csp-adapter/


### PR DESCRIPTION
Updating the helm image to the latest version resolves 2 critical and 14 high severity CVEs identified by `trivy`.