### PR TITLE
[v2.7] Bump bci-micro to 15.6

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-micro:15.4
+FROM registry.suse.com/bci/bci-micro:15.6
 
 ARG user=adapter
 


### PR DESCRIPTION
Bump BCI Micro version to its latest - `15.6`, as `15.4` is already EOL for quite some time.