### PR TITLE
[release/v2.13] Bump Go to 1.24.6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
-  "baseBranchPatterns": ["main"],
+  "baseBranchPatterns": ["release/v2.13"],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/csp-adapter
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20250930175048-be62f9228366


### PR DESCRIPTION
Bump Go to 1.24.6 and change Renovate's base branch.