### PR TITLE
Ensures uniform GO env setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,16 @@
+name: Setup GO
+
+runs:
+  using: composite
+  steps:
+    - name: Get GO Version
+      id: go-version
+      shell: bash
+      run: |
+        GO_VERSION=$(grep -E '^go[[:space:]]+[0-9]+' go.mod | awk '{print $2}')
+        echo "GO=$GO_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Setup GO  
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+      with:
+        go-version: ${{ steps.go-version.outputs.GO }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 
+
+      - name: Setup GO
+        uses: ./.github/actions/setup
 
       - name: Run Build
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
-  GO_VERSION: "1.24.5"
 
 jobs:
   create-release:
@@ -35,20 +34,18 @@ jobs:
     needs: [create-release]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 
 
-      - name: Set up Docker Buildx
+      - name: Setup GO
+        uses: ./.github/actions/setup
+
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
         with:
           buildkitd-flags: --debug
 
-      - name: Set up QEMU
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Run CI
         run: make ci

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ replace (
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.19
-	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.28.3
+	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.36.11
 	github.com/aws/aws-sdk-go-v2/service/sts v1.40.1
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_model v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rancher/csp-adapter
 
-go 1.24.0
-
-toolchain go1.24.6
+go 1.25.4
 
 replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20250930175048-be62f9228366

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.3 h1:x2Ibm/A
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.3/go.mod h1:IW1jwyrQgMdhisceG8fQLmQIydcT/jWY21rFhzgaKwo=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.13 h1:kDqdFvMY4AtKoACfzIGD8A0+hbT41KTKF//gq7jITfM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.13/go.mod h1:lmKuogqSU3HzQCwZ9ZtcqOc5XGMqtDK7OIc2+DxiUEg=
-github.com/aws/aws-sdk-go-v2/service/licensemanager v1.28.3 h1:t9TJdP1zTVnJ2T+DwOw5phK6YDeM5mB6r8OW4kzYhZM=
-github.com/aws/aws-sdk-go-v2/service/licensemanager v1.28.3/go.mod h1:qxdofHNS6n02LO1BPw2gaq3XL+jAtX7bMW00PITkUok=
+github.com/aws/aws-sdk-go-v2/service/licensemanager v1.36.11 h1:4SWJDkonpx+qiWEFhp0ro4/WNrztsFF2OG63h23FOH0=
+github.com/aws/aws-sdk-go-v2/service/licensemanager v1.36.11/go.mod h1:jXdt+CSYTcfzhA60pRhvdlBEGWkHdb96/4+v8hJrYxU=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 h1:/p6MxkbQoCzaGQT3WO0JwG0FlQyG9RD8VmdmoKc5xqU=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.2/go.mod h1:fKvyjJcz63iL/ftA6RaM8sRCtN4r4zl4tjL3qw5ec7k=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6 h1:0dES42T2dhICCbVB3JSTTn7+Bz93wfJEK1b7jksZIyQ=


### PR DESCRIPTION
- alters gha structure to reuse a setup go action across different steps
- adds the following changes from renovate:
    - Update aws-sdk service sts to v1.40.1
    - Update aws-sdk service licensemanager to v1.36.11
    - Update GO to 1.25.4